### PR TITLE
feat: add CMake formatting support to format.py script

### DIFF
--- a/cmake/CheckCompiler.cmake
+++ b/cmake/CheckCompiler.cmake
@@ -1,7 +1,7 @@
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND APPLE)
-    set(is_apple_clang TRUE)
+  set(is_apple_clang TRUE)
 else()
-    set(is_apple_clang FALSE)
+  set(is_apple_clang FALSE)
 endif()
 
 message(STATUS "is_clang_apple: ${is_apple_clang}")


### PR DESCRIPTION
- Add cmake-format capability to the format utility
- Add --cmake-only command line option for formatting only CMake files
- Check for cmake-format in PATH or virtual environment
- Provide helpful error message if cmake-format is not found
- Format CMakeLists.txt and .cmake files throughout the project