### PR TITLE
feat: implement self-relative offsets in catl v2

### DIFF
--- a/repack.sh
+++ b/repack.sh
@@ -1,0 +1,2 @@
+ninja -C build && ./build/src/experiments/catl1-to-catl2 --use-xrpl-defs --input $HOME/projects/xahaud-worktrees/xahaud/cat_all.bin --output $HOME/projects/xahaud-worktrees/xahaud/cat_all.catl2 --log-level info
+ninja -C build && ./build/src/experiments/catl1-to-catl2 --input $HOME/projects/xahaud-worktrees/xahaud/cat_all.catl2  --get-ledger 97480076 --get-key 0002DBD178A4A4033B016621EAA5F503DB8FA6C6B6DF0105FC5B34CC7790D07C

--- a/src/experiments/includes/catl/v2/catl-v2-reader.h
+++ b/src/experiments/includes/catl/v2/catl-v2-reader.h
@@ -970,8 +970,7 @@ private:
                         static_cast<std::uint64_t>(entry.offset_index) *
                             sizeof(rel_off_t);
                     rel_off_t rel = rel_offsets[entry.offset_index];
-                    std::uint64_t child_offset = static_cast<std::uint64_t>(
-                        static_cast<std::int64_t>(slot) + rel);
+                    std::uint64_t child_offset = abs_from_rel(slot, rel);
 
                     bool child_is_leaf = (child_type == ChildType::LEAF);
                     LOGD(
@@ -1118,8 +1117,7 @@ private:
                     static_cast<std::uint64_t>(offset_index) *
                         sizeof(rel_off_t);
                 rel_off_t rel = rel_offsets[offset_index++];
-                info.offset = static_cast<std::uint64_t>(
-                    static_cast<std::int64_t>(slot) + rel);
+                info.offset = abs_from_rel(slot, rel);
                 info.branch = branch;
                 info.is_leaf = (child_type == ChildType::LEAF);
                 children.push_back(info);

--- a/src/experiments/includes/catl/v2/catl-v2-reader.h
+++ b/src/experiments/includes/catl/v2/catl-v2-reader.h
@@ -490,11 +490,24 @@ private:
             throw std::runtime_error("Invalid file magic");
         }
 
-        // Validate version
+        // Validate version (experimental - only version 1 supported)
         if (header_.version != 1)
         {
             throw std::runtime_error(
-                "Unsupported file version: " + std::to_string(header_.version));
+                "Unsupported file version: " + std::to_string(header_.version) +
+                " (experimental code only supports version 1)");
+        }
+        
+        // Check endianness compatibility
+        std::uint32_t host_endian = get_host_endianness();
+        if (header_.endianness != host_endian)
+        {
+            const char* file_endian = (header_.endianness == 0x01020304) ? "big-endian" : "little-endian";
+            const char* host_type = (host_endian == 0x01020304) ? "big-endian" : "little-endian";
+            throw std::runtime_error(
+                std::string("Endianness mismatch: file is ") + file_endian + 
+                ", but host is " + host_type + 
+                ". Cannot mmap files created on different endian systems.");
         }
     }
 

--- a/src/experiments/includes/catl/v2/catl-v2-structs.h
+++ b/src/experiments/includes/catl/v2/catl-v2-structs.h
@@ -322,15 +322,27 @@ struct ChildIterator
 struct CatlV2Header
 {
     std::array<char, 4> magic = {'C', 'A', 'T', '2'};  // CATL v2
-    std::uint32_t version = 1;
+    std::uint32_t version = 1;               // Currently experimental - no version handling yet
+                                             // Will be used for compatibility when out of experimental
     std::uint32_t network_id = 0;           // Network ID (0=XRPL, 21337=Xahau)
+    std::uint32_t endianness = 0x01020304;  // Endianness marker (little=0x04030201, big=0x01020304)
     std::uint64_t ledger_count = 0;         // Number of ledgers in file
     std::uint64_t first_ledger_seq = 0;     // Sequence of first ledger
     std::uint64_t last_ledger_seq = 0;      // Sequence of last ledger
     std::uint64_t ledger_index_offset = 0;  // Offset to ledger index
 };
 #pragma pack(pop)  // Restore default alignment
-static_assert(sizeof(CatlV2Header) == 44, "CatlV2Header must be 44 bytes");
+static_assert(sizeof(CatlV2Header) == 48, "CatlV2Header must be 48 bytes");
+
+/**
+ * Get the host system's endianness marker
+ * @return 0x01020304 for big endian, 0x04030201 for little endian
+ */
+inline std::uint32_t get_host_endianness() {
+    const std::uint32_t test = 0x01020304;
+    const std::uint8_t* bytes = reinterpret_cast<const std::uint8_t*>(&test);
+    return bytes[0] == 0x04 ? 0x04030201 : 0x01020304;
+}
 
 /**
  * Entry in the ledger index

--- a/src/experiments/includes/catl/v2/catl-v2-structs.h
+++ b/src/experiments/includes/catl/v2/catl-v2-structs.h
@@ -318,6 +318,7 @@ struct ChildIterator
  * This format stores multiple ledgers with their canonical headers
  * and serialized state/transaction trees
  */
+#pragma pack(push, 1)  // Ensure consistent binary layout
 struct CatlV2Header
 {
     std::array<char, 4> magic = {'C', 'A', 'T', '2'};  // CATL v2
@@ -328,10 +329,13 @@ struct CatlV2Header
     std::uint64_t last_ledger_seq = 0;      // Sequence of last ledger
     std::uint64_t ledger_index_offset = 0;  // Offset to ledger index
 };
+#pragma pack(pop)  // Restore default alignment
+static_assert(sizeof(CatlV2Header) == 44, "CatlV2Header must be 44 bytes");
 
 /**
  * Entry in the ledger index
  */
+#pragma pack(push, 1)  // Ensure consistent binary layout
 struct LedgerIndexEntry
 {
     std::uint32_t sequence;           // Ledger sequence number
@@ -339,17 +343,22 @@ struct LedgerIndexEntry
     std::uint64_t state_tree_offset;  // Offset to state tree root
     std::uint64_t tx_tree_offset;     // Offset to tx tree root (0 if none)
 };
+#pragma pack(pop)  // Restore default alignment
+static_assert(sizeof(LedgerIndexEntry) == 28, "LedgerIndexEntry must be 28 bytes");
 
 /**
  * Tree size header written after each LedgerInfo
  *
  * This allows readers to skip entire trees without parsing them
  */
+#pragma pack(push, 1)  // Ensure consistent binary layout
 struct TreesHeader
 {
     std::uint64_t state_tree_size;  // Size of state tree in bytes
     std::uint64_t tx_tree_size;     // Size of tx tree in bytes
 };
+#pragma pack(pop)  // Restore default alignment
+static_assert(sizeof(TreesHeader) == 16, "TreesHeader must be 16 bytes");
 
 /**
  * Compression type for future extensibility
@@ -361,8 +370,9 @@ enum class CompressionType : std::uint8_t {
 
 /**
  * Unified leaf header for all leaf nodes
- * Total size: 36 bytes (good alignment)
+ * Total size: 36 bytes (32 + 4, packed)
  */
+#pragma pack(push, 1)  // Ensure consistent binary layout
 struct LeafHeader
 {
     std::array<std::uint8_t, 32> key;  // 32 bytes
@@ -407,6 +417,8 @@ struct LeafHeader
         size_and_flags = (size_and_flags & 0xFF000000) | size;
     }
 };
+#pragma pack(pop)  // Restore default alignment
+static_assert(sizeof(LeafHeader) == 36, "LeafHeader must be 36 bytes");
 
 /**
  * Build child types bitmap from a SHAMapInnerNodeS

--- a/src/experiments/includes/catl/v2/catl-v2-structs.h
+++ b/src/experiments/includes/catl/v2/catl-v2-structs.h
@@ -165,12 +165,12 @@ struct DepthAndFlags
  */
 struct InnerNodeHeader
 {
+    std::uint32_t child_types;  // 2 bits × 16 children = 32 bits
     union
     {
         std::uint16_t depth_plus;  // Raw access for serialization
         DepthAndFlags bits;        // Structured field access
     };
-    std::uint32_t child_types;  // 2 bits × 16 children = 32 bits
     std::uint16_t
         overlay_mask;  // 16 bits: which branches are overridden
                        // 0 => no overlay (current experimental format)

--- a/src/experiments/includes/catl/v2/catl-v2-writer.h
+++ b/src/experiments/includes/catl/v2/catl-v2-writer.h
@@ -404,6 +404,7 @@ private:
         header.bits.depth = inner->get_depth();
         header.bits.rfu = 0;
         header.child_types = build_child_types(inner);
+        header.overlay_mask = 0;  // overlay disabled in this experimental phase
 
         // Count non-empty children
         int child_count = header.count_children();

--- a/src/experiments/includes/catl/v2/catl-v2-writer.h
+++ b/src/experiments/includes/catl/v2/catl-v2-writer.h
@@ -871,10 +871,8 @@ private:
                             std::uint64_t slot = offset_position +
                                 static_cast<std::uint64_t>(i) *
                                     sizeof(rel_off_t);
-                            rels[i] = static_cast<rel_off_t>(
-                                static_cast<std::int64_t>(
-                                    entry.child_offsets[i]) -
-                                static_cast<std::int64_t>(slot));
+                            rels[i] =
+                                rel_from_abs(entry.child_offsets[i], slot);
                         }
                         write_at(
                             offset_position,

--- a/src/experiments/includes/catl/v2/catl-v2-writer.h
+++ b/src/experiments/includes/catl/v2/catl-v2-writer.h
@@ -67,6 +67,9 @@ public:
 
         // Set network ID in header
         header_.network_id = network_id;
+        
+        // Set endianness marker for the current platform
+        header_.endianness = get_host_endianness();
 
         // Write placeholder header
         write_file_header();

--- a/src/shamap/includes/catl/shamap/shamap-leafnode.h
+++ b/src/shamap/includes/catl/shamap/shamap-leafnode.h
@@ -63,7 +63,7 @@ protected:
 
     // CoW support - only accessible to friends
     boost::intrusive_ptr<SHAMapLeafNodeT<Traits>>
-    copy() const;
+    copy(int newVersion) const;
 };
 
 // Type alias for backward compatibility

--- a/src/shamap/src/shamap-collapsed.cpp
+++ b/src/shamap/src/shamap-collapsed.cpp
@@ -136,8 +136,7 @@ SHAMapT<Traits>::collapse_inner_node(
                         if (leaf_child->get_version() != this->current_version_)
                         {
                             // Copy leaf nodes too if needed
-                            auto leaf_copy = leaf_child->copy();
-                            leaf_copy->set_version(this->current_version_);
+                            auto leaf_copy = leaf_child->copy(this->current_version_);
                             node->set_child(i, leaf_copy);
                             continue;
                         }

--- a/src/shamap/src/shamap-leafnode.cpp
+++ b/src/shamap/src/shamap-leafnode.cpp
@@ -101,13 +101,13 @@ SHAMapLeafNodeT<Traits>::get_type() const
 
 template <typename Traits>
 boost::intrusive_ptr<SHAMapLeafNodeT<Traits>>
-SHAMapLeafNodeT<Traits>::copy() const
+SHAMapLeafNodeT<Traits>::copy(int newVersion) const
 {
     auto new_leaf =
         boost::intrusive_ptr(new SHAMapLeafNodeT<Traits>(item, type));
     new_leaf->hash = this->hash;
     new_leaf->hash_valid_ = this->hash_valid_;
-    new_leaf->version = version;
+    new_leaf->version = newVersion;
     return new_leaf;
 }
 

--- a/src/shamap/src/shamap-pathfinder.cpp
+++ b/src/shamap/src/shamap-pathfinder.cpp
@@ -360,8 +360,7 @@ PathFinderT<Traits>::invalidated_possibly_copied_leaf_for_updating(
     // Check if we need to copy the leaf
     if (found_leaf_->get_version() != targetVersion)
     {
-        theLeaf = found_leaf_->copy();
-        theLeaf->set_version(targetVersion);
+        theLeaf = found_leaf_->copy(targetVersion);
         terminal->set_child(terminal_branch_, theLeaf);
         found_leaf_ = theLeaf;  // Update our reference
     }

--- a/src/shamap/src/shamap-set-item-collapsed.cpp
+++ b/src/shamap/src/shamap-set-item-collapsed.cpp
@@ -114,8 +114,7 @@ SHAMapT<Traits>::set_item_collapsed(
             auto existing_leaf = path_finder.get_leaf_mutable();
             if (this->cow_enabled_)
             {
-                existing_leaf = existing_leaf->copy();
-                existing_leaf->set_version(this->current_version_);
+                existing_leaf = existing_leaf->copy(this->current_version_);
             }
             // TODO: leaf cow ?
             new_inner->set_child(

--- a/src/shamap/src/shamap-set-item-reference.cpp
+++ b/src/shamap/src/shamap-set-item-reference.cpp
@@ -142,8 +142,7 @@ SHAMapT<Traits>::set_item_reference(
                         if (existing_leaf->get_version() !=
                             this->current_version_)
                         {
-                            auto copied_leaf = existing_leaf->copy();
-                            copied_leaf->set_version(this->current_version_);
+                            auto copied_leaf = existing_leaf->copy(this->current_version_);
                             existing_leaf = copied_leaf;
                         }
                     }


### PR DESCRIPTION
Convert from absolute 64-bit offsets to self-relative offsets where each
child offset is relative to its own slot position in the file:
  absolute_offset = slot_position + relative_offset

Benefits:
- Backward references (negative offsets) for structural sharing
- Forward references (positive offsets) for new nodes
- Relocatable slices without rebasing
- Future support for incremental/overlay encodings

Changes:
- Add rel_off_t type alias for signed 64-bit relative offsets
- Update ChildIterator to convert relative to absolute on-the-fly
- Modify reader paths to handle relative offset calculations
- Update writer to convert absolute to relative when persisting