### PR TITLE
feat(peermon): add PeerMapping service for reliable validator indexing

### DIFF
--- a/src/lesser-peer/CMakeLists.txt
+++ b/src/lesser-peer/CMakeLists.txt
@@ -57,7 +57,8 @@ add_executable(
   src/monitor/packet-processor.cpp
   src/monitor/packet-logger.cpp
   src/monitor/command-line.cpp
-  src/monitor/peer-dashboard.cpp)
+  src/monitor/peer-dashboard.cpp
+  src/monitor/peer-mapping.cpp)
 
 target_link_libraries(
   peermon

--- a/src/lesser-peer/includes/catl/peer/manifest-tracker.h
+++ b/src/lesser-peer/includes/catl/peer/manifest-tracker.h
@@ -36,9 +36,9 @@ public:
      * Process a manifest blob to extract key mappings
      * @param manifest_data Raw manifest data
      * @param size Size of manifest data
-     * @return true if successfully processed
+     * @return ManifestInfo if successfully processed
      */
-    bool
+    std::optional<ManifestInfo>
     process_manifest(const uint8_t* manifest_data, size_t size);
 
     /**

--- a/src/lesser-peer/includes/catl/peer/monitor/monitor.h
+++ b/src/lesser-peer/includes/catl/peer/monitor/monitor.h
@@ -4,6 +4,7 @@
 #include "catl/peer/monitor/packet-logger.h"
 #include "catl/peer/monitor/packet-processor.h"
 #include "catl/peer/monitor/peer-dashboard.h"
+#include "catl/peer/monitor/peer-mapping.h"
 #include "catl/peer/monitor/types.h"
 #include "catl/peer/peer-connection.h"
 #include "catl/peer/peer-manager.h"
@@ -87,6 +88,7 @@ private:
     std::unique_ptr<packet_processor> processor_;
     std::unique_ptr<PacketLogger> logger_;
     std::shared_ptr<PeerDashboard> dashboard_;
+    std::shared_ptr<PeerMapping> peer_mapping_;
 
     // Log file for dashboard mode
     std::ofstream log_file_;

--- a/src/lesser-peer/includes/catl/peer/monitor/peer-dashboard.h
+++ b/src/lesser-peer/includes/catl/peer/monitor/peer-dashboard.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "catl/peer/monitor/peer-mapping.h"
+
 #include <atomic>
 #include <catl/xdata/protocol.h>
 #include <chrono>
@@ -290,6 +292,13 @@ public:
     std::vector<std::string>
     get_available_endpoints() const;
 
+    // Set peer mapping for validator identity resolution
+    void
+    set_peer_mapping(std::shared_ptr<PeerMapping> mapping)
+    {
+        peer_mapping_ = std::move(mapping);
+    }
+
     // Shutdown callback - called when user quits the dashboard
     using shutdown_callback_t = std::function<void()>;
     void
@@ -409,8 +418,9 @@ private:
     // Known validators (for quorum calculation)
     std::set<std::string>
         known_validators_;  // all validators seen (for quorum)
-    std::map<std::string, std::string>
-        peer_to_validator_;  // peer_id -> master_key (if detected)
+
+    // Peer mapping for validator identity resolution
+    std::shared_ptr<PeerMapping> peer_mapping_;
 
     // LRU cleanup helper
     void

--- a/src/lesser-peer/includes/catl/peer/monitor/peer-mapping.h
+++ b/src/lesser-peer/includes/catl/peer/monitor/peer-mapping.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <map>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace catl::peer::monitor {
+
+class PeerMapping
+{
+public:
+    struct PeerInfo
+    {
+        int index;               // 0-based, extracted from peer-N
+        std::string peer_id;     // "peer-0", "peer-1", ...
+        std::string master_key;  // validator master key (base58)
+    };
+
+    // Called when a validator's validation is first seen for a ledger round.
+    // The delivering peer is likely the direct connection to that validator.
+    // Accumulates votes; the peer that most often delivers first wins.
+    void
+    on_first_validation(
+        std::string const& peer_id,
+        std::string const& validator_key);
+
+    // Lookup: master key → peer index (for V{0-4} display)
+    std::optional<int>
+    get_peer_index(std::string const& master_key) const;
+
+    // All resolved mappings (sorted by index)
+    std::vector<PeerInfo>
+    get_all() const;
+
+    // Count of resolved validators
+    size_t
+    resolved_count() const;
+
+private:
+    static int
+    parse_peer_index(std::string const& peer_id);
+
+    void
+    rebuild_mapping();
+
+    mutable std::mutex mutex_;
+
+    // Vote counts: validator_key → (peer_id → first-delivery count)
+    std::map<std::string, std::map<std::string, int>> first_delivery_votes_;
+
+    // Resolved mapping: master_key → peer index
+    std::map<std::string, int> master_to_index_;
+};
+
+}  // namespace catl::peer::monitor

--- a/src/lesser-peer/includes/catl/peer/monitor/peer-mapping.h
+++ b/src/lesser-peer/includes/catl/peer/monitor/peer-mapping.h
@@ -8,6 +8,20 @@
 
 namespace catl::peer::monitor {
 
+// Maps validator master keys to peer connection indices (V0 = peer-0's
+// validator, etc.) using first-delivery voting.
+//
+// Why voting? In XRPL/Xahau, node identity keys (from the peer handshake
+// Public-Key header) and validator keys are completely separate key pairs
+// loaded from different config sections ([node_seed] vs [validator_token]).
+// There is no protocol message that bridges them. Even xahaud's own
+// reduce_relay::Slots uses a similar observation-based approach internally.
+//
+// How it works: peermon connects directly to each node. When a validation
+// arrives, the delivering peer is recorded. Since the direct path (1 hop)
+// always beats relayed paths (2+ hops through the hub), the peer that most
+// often delivers a validator's validation first is that validator's direct
+// connection. In practice this resolves correctly on the very first round.
 class PeerMapping
 {
 public:

--- a/src/lesser-peer/includes/catl/peer/peer-manager.h
+++ b/src/lesser-peer/includes/catl/peer/peer-manager.h
@@ -173,7 +173,7 @@ private:
     asio::io_context& io_context_;
     asio::ssl::context& ssl_context_;
     std::shared_ptr<PeerEventBus> bus_;
-    std::atomic<std::uint64_t> next_peer_id_{1};
+    std::atomic<std::uint64_t> next_peer_id_{0};
     std::map<std::string, std::shared_ptr<PeerSession>> sessions_;
     mutable std::mutex mutex_;
 };

--- a/src/lesser-peer/src/manifest-tracker.cpp
+++ b/src/lesser-peer/src/manifest-tracker.cpp
@@ -23,7 +23,7 @@ static LogPartition manifest_partition("manifest", []() -> LogLevel {
     return LogLevel::INFO;
 }());
 
-bool
+std::optional<ManifestTracker::ManifestInfo>
 ManifestTracker::process_manifest(const uint8_t* manifest_data, size_t size)
 {
     try
@@ -127,7 +127,7 @@ ManifestTracker::process_manifest(const uint8_t* manifest_data, size_t size)
         if (master_key.empty() || ephemeral_key.empty())
         {
             PLOGE(manifest_partition, "  Failed to extract keys from manifest");
-            return false;
+            return std::nullopt;
         }
 
         // Convert to hex for map keys
@@ -167,12 +167,12 @@ ManifestTracker::process_manifest(const uint8_t* manifest_data, size_t size)
         PLOGI(manifest_partition, "  Ephemeral: ", ephemeral_base58);
         PLOGI(manifest_partition, "  Sequence:  ", sequence);
 
-        return true;
+        return info;
     }
     catch (std::exception const& e)
     {
         PLOGE(manifest_partition, "Failed to process manifest: ", e.what());
-        return false;
+        return std::nullopt;
     }
 }
 

--- a/src/lesser-peer/src/monitor/monitor.cpp
+++ b/src/lesser-peer/src/monitor/monitor.cpp
@@ -47,6 +47,9 @@ peer_monitor::peer_monitor(monitor_config config)
         }
     });
 
+    // Create peer mapping service
+    peer_mapping_ = std::make_shared<PeerMapping>();
+
     // Create dashboard only if enabled
     if (config_.view == ViewMode::Dashboard)
     {
@@ -56,6 +59,8 @@ peer_monitor::peer_monitor(monitor_config config)
             config_.peer.protocol_definitions_path, config_.peer.network_id);
         // Set dashboard on processor for ledger/validation updates
         processor_->set_dashboard(dashboard_);
+        // Share peer mapping with dashboard
+        dashboard_->set_peer_mapping(peer_mapping_);
         // Register shutdown callback so 'q' in dashboard stops the monitor
         dashboard_->set_shutdown_callback([this]() { request_stop(); });
     }

--- a/src/lesser-peer/src/monitor/peer-dashboard.cpp
+++ b/src/lesser-peer/src/monitor/peer-dashboard.cpp
@@ -1928,7 +1928,7 @@ PeerDashboard::run_ui()
                         status_icon = "○";
                     }
 
-                    std::string peer_num = std::to_string(i + 1) + ".";
+                    std::string peer_num = std::to_string(i) + ".";
 
                     // Check if this peer is actively receiving or reconnecting
                     auto peer_since_last =
@@ -1983,7 +1983,7 @@ PeerDashboard::run_ui()
 
             // Connection info section (for primary peer)
             auto connection_section = vbox({
-                text("🌐 PRIMARY PEER (1)") | bold | color(Color::Cyan),
+                text("🌐 PRIMARY PEER (0)") | bold | color(Color::Cyan),
                 separator(),
                 hbox({
                     text("Status: "),
@@ -2198,7 +2198,8 @@ PeerDashboard::run_ui()
             // Debug section for protocol type resolution
             Elements debug_elements;
             debug_elements.push_back(
-                text("🔧 DEBUG: Type Resolution") | bold | color(Color::Yellow));
+                text("🔧 DEBUG: Type Resolution") | bold |
+                color(Color::Yellow));
             debug_elements.push_back(separator());
             if (protocol_)
             {
@@ -2351,7 +2352,7 @@ PeerDashboard::run_ui()
                 std::map<std::string, int> validator_index;
                 {
                     std::lock_guard<std::mutex> lock(consensus_mutex_);
-                    int idx = 1;
+                    int idx = 0;
                     for (auto const& vk : known_validators_)
                     {
                         validator_index[vk] = idx++;
@@ -3067,9 +3068,8 @@ PeerDashboard::run_ui()
                     Color status_color = peer.connected
                         ? Color::GreenLight
                         : (is_reconnecting ? Color::Yellow : Color::Red);
-                    std::string status_icon = peer.connected
-                        ? "🟢"
-                        : (is_reconnecting ? "🟡" : "🔴");
+                    std::string status_icon =
+                        peer.connected ? "🟢" : (is_reconnecting ? "🟡" : "🔴");
 
                     // Short address for display
                     std::string addr = peer.peer_address;

--- a/src/lesser-peer/src/monitor/peer-dashboard.cpp
+++ b/src/lesser-peer/src/monitor/peer-dashboard.cpp
@@ -2406,14 +2406,21 @@ PeerDashboard::run_ui()
                     return result;
                 };
 
+                // Timing info for first/last validator
+                struct ValidatorTiming
+                {
+                    std::string validator_key;
+                    int64_t delta_ms;
+                };
+
                 // Helper to render txset info
-                // delta_ms: milliseconds since reference time (negative if
-                // before), nullopt to hide
+                // first/last: timing info for first and last validators
                 auto render_txset_info =
                     [&](std::string const& txset_hash,
                         std::set<std::string> const& validators,
                         bool is_winner,
-                        std::optional<int64_t> delta_ms =
+                        std::optional<ValidatorTiming> first = std::nullopt,
+                        std::optional<ValidatorTiming> last =
                             std::nullopt) -> Elements {
                     Elements els;
                     Color hash_color =
@@ -2426,15 +2433,26 @@ PeerDashboard::run_ui()
                     std::string validator_str =
                         format_validator_set(validators);
 
-                    // Format delta string
-                    std::string delta_str;
-                    if (delta_ms.has_value())
+                    // Format timing string: "n1=+100ms" or "n1=+100ms,
+                    // n3=+500ms"
+                    std::string timing_str;
+                    auto format_timing = [&](ValidatorTiming const& t) {
+                        auto it = validator_index.find(t.validator_key);
+                        int idx = it != validator_index.end() ? it->second : 0;
+                        std::string ms_str = t.delta_ms >= 0
+                            ? "+" + std::to_string(t.delta_ms) + "ms"
+                            : std::to_string(t.delta_ms) + "ms";
+                        return "n" + std::to_string(idx) + "=" + ms_str;
+                    };
+
+                    if (first.has_value())
                     {
-                        int64_t ms = delta_ms.value();
-                        if (ms >= 0)
-                            delta_str = "+" + std::to_string(ms) + "ms";
-                        else
-                            delta_str = std::to_string(ms) + "ms";
+                        timing_str = format_timing(first.value());
+                        if (last.has_value() &&
+                            last->validator_key != first->validator_key)
+                        {
+                            timing_str += ", " + format_timing(last.value());
+                        }
                     }
 
                     els.push_back(hbox({
@@ -2442,8 +2460,8 @@ PeerDashboard::run_ui()
                         text(short_hash) | bold | color(hash_color),
                         text(" ") | dim,
                         text(validator_str) | color(hash_color),
-                        delta_str.empty() ? text("")
-                                          : text(" " + delta_str) | dim,
+                        timing_str.empty() ? text("")
+                                           : text(" " + timing_str) | dim,
                     }));
 
                     auto txset_it = txset_data.find(txset_hash);
@@ -2628,13 +2646,16 @@ PeerDashboard::run_ui()
                     }));
                     elements.push_back(separator());
 
-                    // Get seq=0 proposals only - collect validators and first
-                    // seen time
+                    // Get seq=0 proposals only - collect validators and
+                    // first/last seen times
                     struct TxSetEntry
                     {
                         std::string hash;
                         std::set<std::string> validators;
                         std::chrono::steady_clock::time_point first_seen;
+                        std::chrono::steady_clock::time_point last_seen;
+                        std::string first_validator;
+                        std::string last_validator;
                     };
                     std::map<std::string, TxSetEntry> txset_map;
                     for (auto const& event : props.timeline)
@@ -2646,6 +2667,18 @@ PeerDashboard::run_ui()
                             {
                                 entry.hash = event.tx_set_hash;
                                 entry.first_seen = event.received_at;
+                                entry.first_validator = event.validator_key;
+                                entry.last_seen = event.received_at;
+                                entry.last_validator = event.validator_key;
+                            }
+                            else
+                            {
+                                // Update last seen if this is newer
+                                if (event.received_at > entry.last_seen)
+                                {
+                                    entry.last_seen = event.received_at;
+                                    entry.last_validator = event.validator_key;
+                                }
                             }
                             entry.validators.insert(event.validator_key);
                         }
@@ -2691,13 +2724,24 @@ PeerDashboard::run_ui()
                     for (auto const& entry : txsets)
                     {
                         bool is_majority = (entry.hash == majority_hash);
-                        // Calculate delta in milliseconds
-                        auto delta = std::chrono::duration_cast<
-                                         std::chrono::milliseconds>(
-                                         entry.first_seen - ref_time)
-                                         .count();
+                        // Calculate first/last timing
+                        auto first_delta = std::chrono::duration_cast<
+                                               std::chrono::milliseconds>(
+                                               entry.first_seen - ref_time)
+                                               .count();
+                        auto last_delta = std::chrono::duration_cast<
+                                              std::chrono::milliseconds>(
+                                              entry.last_seen - ref_time)
+                                              .count();
+                        ValidatorTiming first{
+                            entry.first_validator, first_delta};
+                        ValidatorTiming last{entry.last_validator, last_delta};
                         auto info = render_txset_info(
-                            entry.hash, entry.validators, is_majority, delta);
+                            entry.hash,
+                            entry.validators,
+                            is_majority,
+                            first,
+                            last);
                         for (auto& el : info)
                             elements.push_back(std::move(el));
                     }
@@ -2722,13 +2766,16 @@ PeerDashboard::run_ui()
 
                     auto const& props = *curr_props_opt;
 
-                    // Get seq=N proposals only - collect validators and first
-                    // seen time
+                    // Get seq=N proposals only - collect validators and
+                    // first/last seen times
                     struct TxSetEntry
                     {
                         std::string hash;
                         std::set<std::string> validators;
                         std::chrono::steady_clock::time_point first_seen;
+                        std::chrono::steady_clock::time_point last_seen;
+                        std::string first_validator;
+                        std::string last_validator;
                     };
                     std::map<std::string, TxSetEntry> txset_map;
                     for (auto const& event : props.timeline)
@@ -2740,6 +2787,17 @@ PeerDashboard::run_ui()
                             {
                                 entry.hash = event.tx_set_hash;
                                 entry.first_seen = event.received_at;
+                                entry.first_validator = event.validator_key;
+                                entry.last_seen = event.received_at;
+                                entry.last_validator = event.validator_key;
+                            }
+                            else
+                            {
+                                if (event.received_at > entry.last_seen)
+                                {
+                                    entry.last_seen = event.received_at;
+                                    entry.last_validator = event.validator_key;
+                                }
                             }
                             entry.validators.insert(event.validator_key);
                         }
@@ -2785,12 +2843,23 @@ PeerDashboard::run_ui()
                     for (auto const& entry : txsets)
                     {
                         bool is_majority = (entry.hash == majority_hash);
-                        auto delta = std::chrono::duration_cast<
-                                         std::chrono::milliseconds>(
-                                         entry.first_seen - ref_time)
-                                         .count();
+                        auto first_delta = std::chrono::duration_cast<
+                                               std::chrono::milliseconds>(
+                                               entry.first_seen - ref_time)
+                                               .count();
+                        auto last_delta = std::chrono::duration_cast<
+                                              std::chrono::milliseconds>(
+                                              entry.last_seen - ref_time)
+                                              .count();
+                        ValidatorTiming first{
+                            entry.first_validator, first_delta};
+                        ValidatorTiming last{entry.last_validator, last_delta};
                         auto info = render_txset_info(
-                            entry.hash, entry.validators, is_majority, delta);
+                            entry.hash,
+                            entry.validators,
+                            is_majority,
+                            first,
+                            last);
                         for (auto& el : info)
                             elements.push_back(std::move(el));
                     }
@@ -2833,6 +2902,9 @@ PeerDashboard::run_ui()
                         std::string hash;
                         std::set<std::string> validators;
                         std::chrono::steady_clock::time_point first_seen;
+                        std::chrono::steady_clock::time_point last_seen;
+                        std::string first_validator;
+                        std::string last_validator;
                     };
                     std::map<std::string, TxSetEntry> txset_map;
                     for (auto const& event : props.timeline)
@@ -2844,6 +2916,17 @@ PeerDashboard::run_ui()
                             {
                                 entry.hash = event.tx_set_hash;
                                 entry.first_seen = event.received_at;
+                                entry.first_validator = event.validator_key;
+                                entry.last_seen = event.received_at;
+                                entry.last_validator = event.validator_key;
+                            }
+                            else
+                            {
+                                if (event.received_at > entry.last_seen)
+                                {
+                                    entry.last_seen = event.received_at;
+                                    entry.last_validator = event.validator_key;
+                                }
                             }
                             entry.validators.insert(event.validator_key);
                         }
@@ -2884,12 +2967,23 @@ PeerDashboard::run_ui()
                     for (auto const& entry : txsets)
                     {
                         bool is_majority = (entry.hash == majority_hash);
-                        auto delta = std::chrono::duration_cast<
-                                         std::chrono::milliseconds>(
-                                         entry.first_seen - ref_time)
-                                         .count();
+                        auto first_delta = std::chrono::duration_cast<
+                                               std::chrono::milliseconds>(
+                                               entry.first_seen - ref_time)
+                                               .count();
+                        auto last_delta = std::chrono::duration_cast<
+                                              std::chrono::milliseconds>(
+                                              entry.last_seen - ref_time)
+                                              .count();
+                        ValidatorTiming first{
+                            entry.first_validator, first_delta};
+                        ValidatorTiming last{entry.last_validator, last_delta};
                         auto info = render_txset_info(
-                            entry.hash, entry.validators, is_majority, delta);
+                            entry.hash,
+                            entry.validators,
+                            is_majority,
+                            first,
+                            last);
                         for (auto& el : info)
                             elements.push_back(std::move(el));
                     }

--- a/src/lesser-peer/src/monitor/peer-dashboard.cpp
+++ b/src/lesser-peer/src/monitor/peer-dashboard.cpp
@@ -319,9 +319,6 @@ PeerDashboard::record_validation(
     // Add validator to known set
     known_validators_.insert(validator_key);
 
-    // Track which peer this validator's validations came from
-    peer_to_validator_[peer_id] = validator_key;
-
     // Always add to ledger_validations_ map - never reject based on sequence
     auto& consensus = ledger_validations_[ledger_seq];
     if (consensus.sequence == 0)
@@ -338,13 +335,18 @@ PeerDashboard::record_validation(
     auto it = validators.find(validator_key);
     if (it == validators.end())
     {
-        // New validator for this ledger
+        // New validator for this ledger - this peer delivered first
         ValidatorInfo info;
         info.master_key_hex = validator_key;
         info.ephemeral_key_hex = ephemeral_key;
         info.seen_from_peers.insert(peer_id);
         info.first_seen = now;
         validators[validator_key] = std::move(info);
+
+        // Notify peer mapping: this peer was first to deliver this
+        // validator's validation (likely the direct connection)
+        if (peer_mapping_)
+            peer_mapping_->on_first_validation(peer_id, validator_key);
     }
     else
     {
@@ -2348,14 +2350,25 @@ PeerDashboard::run_ui()
                     txset_data = txset_acquisitions_;
                 }
 
-                // Build validator key -> index mapping (stable ordering)
+                // Build validator key -> index mapping (from peer mapping)
                 std::map<std::string, int> validator_index;
+                if (peer_mapping_)
+                {
+                    auto mappings = peer_mapping_->get_all();
+                    for (auto const& info : mappings)
+                    {
+                        if (!info.master_key.empty())
+                            validator_index[info.master_key] = info.index;
+                    }
+                }
+                // Fallback for validators not mapped to a connected peer
                 {
                     std::lock_guard<std::mutex> lock(consensus_mutex_);
-                    int idx = 0;
+                    int next_idx = static_cast<int>(validator_index.size());
                     for (auto const& vk : known_validators_)
                     {
-                        validator_index[vk] = idx++;
+                        if (validator_index.find(vk) == validator_index.end())
+                            validator_index[vk] = next_idx++;
                     }
                 }
 

--- a/src/lesser-peer/src/monitor/peer-mapping.cpp
+++ b/src/lesser-peer/src/monitor/peer-mapping.cpp
@@ -1,0 +1,155 @@
+#include <catl/core/logger.h>
+#include <catl/peer/monitor/peer-mapping.h>
+
+#include <algorithm>
+#include <set>
+
+namespace catl::peer::monitor {
+
+static LogPartition&
+peer_mapping_log()
+{
+    static LogPartition partition("PEERMAP", LogLevel::INFO);
+    return partition;
+}
+
+int
+PeerMapping::parse_peer_index(std::string const& peer_id)
+{
+    auto pos = peer_id.find('-');
+    if (pos != std::string::npos && pos + 1 < peer_id.size())
+        return std::stoi(peer_id.substr(pos + 1));
+    return -1;
+}
+
+void
+PeerMapping::on_first_validation(
+    std::string const& peer_id,
+    std::string const& validator_key)
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    first_delivery_votes_[validator_key][peer_id]++;
+    rebuild_mapping();
+}
+
+std::optional<int>
+PeerMapping::get_peer_index(std::string const& master_key) const
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = master_to_index_.find(master_key);
+    if (it != master_to_index_.end())
+        return it->second;
+    return std::nullopt;
+}
+
+std::vector<PeerMapping::PeerInfo>
+PeerMapping::get_all() const
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    std::vector<PeerInfo> result;
+    result.reserve(master_to_index_.size());
+    for (auto const& [master_key, index] : master_to_index_)
+    {
+        PeerInfo info;
+        info.index = index;
+        info.master_key = master_key;
+        // Find the winning peer_id for this validator
+        auto vit = first_delivery_votes_.find(master_key);
+        if (vit != first_delivery_votes_.end())
+        {
+            int best_count = 0;
+            for (auto const& [pid, count] : vit->second)
+            {
+                if (count > best_count)
+                {
+                    best_count = count;
+                    info.peer_id = pid;
+                }
+            }
+        }
+        result.push_back(std::move(info));
+    }
+    std::sort(
+        result.begin(), result.end(), [](PeerInfo const& a, PeerInfo const& b) {
+            return a.index < b.index;
+        });
+    return result;
+}
+
+size_t
+PeerMapping::resolved_count() const
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    return master_to_index_.size();
+}
+
+void
+PeerMapping::rebuild_mapping()
+{
+    // For each validator, find the peer that most frequently delivers first
+    // Then assign that peer's index to the validator.
+    // Resolve greedily: highest vote count first, no index conflicts.
+
+    struct Candidate
+    {
+        std::string validator_key;
+        std::string peer_id;
+        int peer_index;
+        int votes;
+    };
+
+    std::vector<Candidate> candidates;
+    for (auto const& [vk, peer_counts] : first_delivery_votes_)
+    {
+        for (auto const& [pid, count] : peer_counts)
+        {
+            int idx = parse_peer_index(pid);
+            if (idx >= 0)
+                candidates.push_back({vk, pid, idx, count});
+        }
+    }
+
+    // Sort by votes descending (greedy: strongest associations first)
+    std::sort(
+        candidates.begin(),
+        candidates.end(),
+        [](Candidate const& a, Candidate const& b) {
+            return a.votes > b.votes;
+        });
+
+    std::map<std::string, int> new_mapping;
+    std::set<int> used_indices;
+    std::set<std::string> mapped_validators;
+
+    for (auto const& c : candidates)
+    {
+        if (mapped_validators.count(c.validator_key))
+            continue;
+        if (used_indices.count(c.peer_index))
+            continue;
+
+        new_mapping[c.validator_key] = c.peer_index;
+        used_indices.insert(c.peer_index);
+        mapped_validators.insert(c.validator_key);
+    }
+
+    // Log if mapping changed
+    if (new_mapping != master_to_index_)
+    {
+        PLOGI(peer_mapping_log(), "mapping updated:");
+        for (auto const& [vk, idx] : new_mapping)
+        {
+            PLOGI(
+                peer_mapping_log(),
+                "  V",
+                idx,
+                " -> ",
+                vk.substr(0, 12),
+                "...");
+        }
+    }
+
+    master_to_index_ = std::move(new_mapping);
+}
+
+}  // namespace catl::peer::monitor

--- a/src/lesser-peer/src/monitor/peer-mapping.cpp
+++ b/src/lesser-peer/src/monitor/peer-mapping.cpp
@@ -2,6 +2,7 @@
 #include <catl/peer/monitor/peer-mapping.h>
 
 #include <algorithm>
+#include <cstring>
 #include <set>
 
 namespace catl::peer::monitor {


### PR DESCRIPTION
## Summary
- **PeerMapping service**: New `PeerMapping` class that uses validation first-delivery voting to reliably map validators to peer indices. The peer that most frequently delivers a validator's validation first is identified as the direct connection, giving stable V{0-4} indices matching peer order.
- **0-based indexing**: Changed peers and validators from 1-based to 0-based throughout (peer-0, V{0-4}, n0=+100ms)
- **First/last validator timestamps**: Proposals tab now shows timing of first and last validator seen (e.g. `n3=+0ms, n4=+100ms`)

## Background
Validator indices were broken because `peer_to_validator_` was populated from relayed validations — any peer relays all validators' validations, so the mapping was unreliable. The HTTP upgrade `Public-Key` header turned out to be the node identity key (not the validator ephemeral key), so that approach didn't work either. The voting-based approach reliably identifies the direct connection within a single ledger round.

## Test plan
- [x] `peer_manager_gtest` passes (4 tests)
- [x] `peermon` builds and runs against 5-node testnet
- [x] V{0,2-4} correctly shown when node 1 is down (not V{0-3})
- [x] V{0-4} shown when all nodes proposing
- [x] Mapping resolves within first ledger round (confirmed via PEERMAP logs)